### PR TITLE
chore: add devcontainer with java17

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/java:17",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-java-pack"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Thanks for a very nice utility (+1 to https://github.com/ris58h/exkeymo-web/issues/1)!

Since the heroku-site is down, it may be nice to give users a devcontainers file with correct java version, that way they are only a click away from having a dev environment with Java 17 installed and ready to install with Maven and run the jar-files.

![image](https://github.com/ris58h/exkeymo-web/assets/2505178/efe67b94-3bc7-470e-9074-06a088e961f7)
